### PR TITLE
Reconnect on failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,15 @@ pub fn listen_loop(
                     }
                 };
             }
-            socket.read_message()?
+            match socket.read_message() {
+                Ok(msg) => msg,
+                Err(err) => match err {
+                    tungstenite::Error::ConnectionClosed => continue,
+                    _ => return Err(err.into()),
+                },
+            }
         };
+
         let msg_raw = msg.to_text()?.to_owned();
         let msg: TwitchMessage = match serde_json::from_str(&msg_raw) {
             Ok(msg) => msg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,8 @@ pub fn listen_loop(
             match socket.read_message() {
                 Ok(msg) => msg,
                 Err(err) => match err {
-                    tungstenite::Error::ConnectionClosed => continue,
-                    _ => return Err(err.into()),
+                    tungstenite::Error::ConnectionClosed => return Err(err.into()),
+                    _ => continue,
                 },
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@ pub fn listen_loop(
                 Ok(msg) => msg,
                 Err(err) => match err {
                     tungstenite::Error::ConnectionClosed => return Err(err.into()),
-                    tungstenite::Error::Io(_) => {
+                    tungstenite::Error::Io(err) => {
                         let mut reconnect_timer = 1;
-                        println!("Connection lost, reconnecting...");
+                        println!("Connection lost\n\t{}\n\tReconnecting...", err.to_string());
                         loop {
                             match get_session(None) {
                                 Ok(new_session) => {
@@ -60,8 +60,9 @@ pub fn listen_loop(
                                 Err(err) => {
                                     thread::sleep(Duration::from_secs(reconnect_timer));
                                     println!(
-                                        "Failed to connect\n\tError: {}\n\tretrying in {}s...",
-                                        err, reconnect_timer
+                                        "Failed to connect:\n\t{}\n\tRetrying in {}s...",
+                                        err.to_string(),
+                                        reconnect_timer
                                     );
                                     reconnect_timer *= 2;
                                 }


### PR DESCRIPTION
When the underlying connection dies unexpectedly, try reconnecting with exponential backoff.  
This should handle the case in which the internet connection drops entirely, for example.  
Note that a reconnection of this type requires resubscribing to any EventSub notifications, while a reconnection triggered by Twitch sending a `Reconnect` message does *not.*  
Downstream code will have to manually check if their subscriptions are active whenever a `Welcome` message comes in.  
If the subscriptions are gone, resubscribe. If the subscriptions are still there, the new connection was triggered by Twitch's `Reconnect` message.